### PR TITLE
Fix typos and formatting

### DIFF
--- a/mkdocs_macros/context.py
+++ b/mkdocs_macros/context.py
@@ -265,7 +265,7 @@ def is_relative(url):
 
 def fix_url(url):
     """
-    If url is relative, fix it so that it points to the docs diretory.
+    If url is relative, fix it so that it points to the docs directory.
     This is necessary because relative links in markdown must be adapted
     in html ('img/foo.png' => '../img/img.png').
     """

--- a/update_pypi.sh
+++ b/update_pypi.sh
@@ -2,7 +2,7 @@
 # update the package on pypi
 #
 # Tip: if you don't want to retype pypi's username every time
-#      define it as an environement variable (TWINE_USERNAME)
+#      define it as an environment variable (TWINE_USERNAME)
 # -------------------------------------------------------------
 function warn {
     GREEN='\033[0;32m'

--- a/webdoc/docs/contribute.md
+++ b/webdoc/docs/contribute.md
@@ -50,7 +50,7 @@ for maintenance, open an issue on the [project's forum](https://github.com/frala
 ## Pull Requests
 
 Contributions of [PRs (Pull Requests)](https://github.com/fralau/mkdocs_macros_plugin/pulls) are welcome (but only after an issue
-has already beed discussed).
+has already been discussed).
 
 Always indicate, in the pull request, the number of the issue (e.g. #15)
 that refers to the problem you are seeking to solve.

--- a/webdoc/docs/git_info.md
+++ b/webdoc/docs/git_info.md
@@ -110,7 +110,7 @@ which would return e.g.
 The tag attribute shows the full description of the tag, for
 example `v1.0.4-14-g2414721`. Meanwhile, `short_tag` shows the
 tag name without any suffix, for example `v1.0.4`. The later can
-be usefull when showing the latest release.
+be useful when showing the latest release.
 
 ## Tip: Is this really a git repo?
 

--- a/webdoc/docs/index.md
+++ b/webdoc/docs/index.md
@@ -5,7 +5,7 @@ static website generator, with the use of variables and macros.**
 
 !!! Tip "A mini-framework"
     Mkdocs-Macros is more than a "plugin". It is a **mini-framework**
-    developped with one goal in mind: 
+    developed with one goal in mind: 
     
     **To enhance mkdocs with the macro and automation capabilities
     available to a [wiki engine](https://wiki.c2.com/?WikiEngine).** [^6]

--- a/webdoc/docs/macros.md
+++ b/webdoc/docs/macros.md
@@ -43,7 +43,7 @@ raise an error.**
 
 ### Preinstalled modules (pluglets)
 
-If you wish to re-use modules across several documentation projects,
+If you wish to reuse modules across several documentation projects,
 you may want to pre-install them, turning them into [**pluglets**](pluglets.md).
 
 
@@ -171,7 +171,7 @@ or functions of that object:
 
 Item|Type|Description
 ---|---|---
-`variables`|_attribute_|The namespace that contains the variables and macros that will be available in mardkown pages with `{{ ... }}` notation. This dictionary is initialized with the values contained in the `extra` section of the configuration file (and optionally, with external yaml files). This object is also accessible with the dot notation; e.g. `env.variables['foo']` is equivalent to `env.variables.foo`.
+`variables`|_attribute_|The namespace that contains the variables and macros that will be available in markdown pages with `{{ ... }}` notation. This dictionary is initialized with the values contained in the `extra` section of the configuration file (and optionally, with external yaml files). This object is also accessible with the dot notation; e.g. `env.variables['foo']` is equivalent to `env.variables.foo`.
 `macro`|_function_|A decorator function that you can use to declare a Python function as a Jinja2 callable ('macro' for MkDocs).
 `filters`|_attribute_|A list list of jinja2 filters (default None)
 `filter`|_function_|A decorator for declaring a Python function as a jinja2 custom filter
@@ -211,7 +211,7 @@ def site_info():
 ```
 
 !!! Warning "Beware the change of name"
-    Beware that the what is usually called `config` is alled `env.conf`
+    Beware that the what is usually called `config` is allied `env.conf`
     in the module. That is is because there is already `env.config`
     property as part of the `BasePlugin` class.
 

--- a/webdoc/docs/post_production.md
+++ b/webdoc/docs/post_production.md
@@ -62,10 +62,10 @@ each page, not on the general configuration),
 you may use the two hooks in your module, which are executed
  _before_ the markdown page is rendered into HTML:
 
-1. `on_pre_page_macros(env)` : just ** before ** the macros are rendered
+1. `on_pre_page_macros(env)` : just **before** the macros are rendered
    on a specific page (macros are still present).
    At this stage you can still insert text that contains macros.
-2. `on_post_page_macros(env)` : just ** after ** the macros are rendered
+2. `on_post_page_macros(env)` : just **after** the macros are rendered
    on a specific page (macros have turned into their markdown equivalent).
    At this stage you can insert Markdown text or HTML, but no longer
    macros.
@@ -150,8 +150,8 @@ def on_pre_page_macros(env):
 `on_pre_page_macros(env)` and `on_post_page_macros(env)` are executed by the
 [`on_page_markdown()` event of MkDocs](https://www.mkdocs.org/user-guide/plugins/#on_page_markdown):
 
-- ** before or after** rendering of the macros into raw Markdown, respectively
-- ** before** the rendering the page from Markdown to HTML
+- **before or after** rendering of the macros into raw Markdown, respectively
+- **before** the rendering the page from Markdown to HTML
 
 They operates on all pages, page by page.
 

--- a/webdoc/docs/post_production.md
+++ b/webdoc/docs/post_production.md
@@ -165,7 +165,7 @@ They operates on all pages, page by page.
 #### Content and availability of attributes
 the `env. markdown` and `env.page` attributes are available
  only from the point of `on_pre_page_macros()` on. 
-Thay are **not** available for the `define_env(env)` hook.
+They are **not** available for the `define_env(env)` hook.
 
 env.markdown contains the markdown of the page, before rendering
 (in `on_pre_page_macros()`) or after rendering (in `on_post_page_macros()`))

--- a/webdoc/docs/rendering.md
+++ b/webdoc/docs/rendering.md
@@ -19,7 +19,7 @@ may not be rendered correctly,
 or cause a syntax error, or some other error.
 
 The reason is that, by default, when the Jinja2 template engine in the **macro plugin** 
-encouters any text that has the standard markers (typically starting with `{%`} or
+encounters any text that has the standard markers (typically starting with `{%`} or
 `{{`) this will cause a conflict:
 it will try to interpret that text as a macro
 and fail to behave properly. 
@@ -111,7 +111,7 @@ For example, the following LaTeX snippet is used to draw a table:
     This is to allow advanced use cases where the content of the code block
     must be computed on the fly.
 
-!!! Note "No Risk of intereference of Jinja2 statements with HTML Rendering"
+!!! Note "No Risk of interference of Jinja2 statements with HTML Rendering"
 
     There is, of course, a **third use of Jinja2 statements**:
     MkDocs also use them in templates to render HTML pages. **Fortunately,
@@ -181,7 +181,7 @@ _From version 1.0.0_
     problematic pages, or do not wish to control
     the rendering of all pages, this solution may be for you.
 
-The **opt-in** solution consists of changing the defaut behavior of 
+The **opt-in** solution consists of changing the default behavior of 
 mkdocs-macros: no pages will be rendered (no macros interpreted)
 unless this is specifically requested in the page's header.
 

--- a/webdoc/docs/tips.md
+++ b/webdoc/docs/tips.md
@@ -293,7 +293,7 @@ custom macros,  you could declare the following macro:
             return {name:getattr(env, name) for name in dir(env) if not name.startswith('_')}
 
 
-And call it in witin a mardkown page:
+And call it in within a markdown page:
 
     ```
     {{ doc_env() | pprint }}

--- a/webdoc/mkdocs.yml
+++ b/webdoc/mkdocs.yml
@@ -49,11 +49,11 @@ markdown_extensions:
 
 plugins:
   # do not use the macros plugin, for 
-  # 1. a question of "boostrap" (avoid chicken and the egg issues)
+  # 1. a question of "bootstrap" (avoid chicken and the egg issues)
   # 2. avoid interpreting the jinja2 code examples as instructions.
   - search
   - include-markdown:
-      # This is changed so that real include doesn't interefere with examples
+      # This is changed so that real include doesn't interfere with examples
       opening_tag: "[%"
       closing_tag: "%]"
   - mermaid2


### PR DESCRIPTION
Most typos are found with the help of `codespell` - https://github.com/codespell-project/codespell 😃 