### PR TITLE
Fix encoding issue for other characters set

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -373,7 +373,7 @@ class MacrosPlugin(BasePlugin):
             # Paths are be relative to the project root.
             filename = os.path.join(self.project_dir, filename)
             if os.path.isfile(filename):
-                with open(filename) as f:
+                with open(filename, encoding="utf-8") as f:
                     # load the yaml file
                     # NOTE: for the SafeLoader argument, see: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
                     content = yaml.load(f, Loader=yaml.SafeLoader)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ TEST_REQUIRE = ['mkdocs-macros-test', 'mkdocs-material>=6.2',
 
 def read_file(fname):
     "Read a local file"
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf-8").read()
 
 
 setup(


### PR DESCRIPTION
Fix: https://github.com/fralau/mkdocs-macros-plugin/issues/227 

This commit is to set the encoding when open a file. It's helpful for other characters set users because the file in other characters set device may be encoded  by other special set. 