### PR TITLE
Add type marker for PEP 561 compliance

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE.md
 include mkdocs_macros/*.md
+include mkdocs_macros/py.typed


### PR DESCRIPTION
This adds a `py.typed` file in the package directory, which acts as a marker to declare that it is PEP 561 compliant and includes type hints.

More information is available here:

https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

Fixes #219.