### PR TITLE
Enhance ImportError handling in plugin.py

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -590,8 +590,12 @@ class MacrosPlugin(BasePlugin):
             trace("Found local Python module '%s' in:" % local_module_name,
                   self.project_dir)
             self._load_module(module, local_module_name)
-        except ImportError:
+        except ImportError as e:
             if local_module_name == DEFAULT_MODULE_NAME:
+                module_path = os.path.join(self.project_dir,
+                                           local_module_name + '.py')
+                if os.path.isfile(module_path):
+                    raise
                 # do not do anything if there is no main module
                 trace("No default module `%s` found" % DEFAULT_MODULE_NAME)
             else:


### PR DESCRIPTION
I've just gone through some debugging nightmare. And wanted to share what help me. :)

Currently when the default main module exists but fails to import (e.g. due to a ModuleNotFoundError in one of its imports), the exception is silently swallowed and logged only as No default module 'main' found. This makes debugging extremely difficult as the real error is completely hidden.

The fix re-raises as a chained exception when the module file actually exists, preserving the original traceback while keeping the existing behaviour (silent skip) when the file genuinely doesn't exist.

Disclaimer: Claude 4.6 was used for debugging and fix creation